### PR TITLE
Copy cart id button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Copy cart id button
+
 ## [0.3.1] - 2022-09-14
 
 ## [0.3.0] - 2022-03-03

--- a/react/components/Actions.js
+++ b/react/components/Actions.js
@@ -25,11 +25,14 @@ class Actions extends Component {
   }
 
   handleCopyOFId = () => {
-    this.setState({...this.state, orderFormIdCopied: true})
+    this.setState({orderFormIdCopied: true})
+    setTimeout(
+      function() { this.setState({orderFormIdCopied: false});
+    }.bind(this), 2000)
   }
 
   handleResetCopyOFIdButton = () => {
-    this.setState({...this.state, orderFormIdCopied: false})
+    this.setState({orderFormIdCopied: false})
   }
 
   handleCopyCartButton = () => {
@@ -71,7 +74,7 @@ class Actions extends Component {
         <span>
           <Button onClick={this.handleResetCartButton} secondary><FormattedMessage id="cartman.emptyCart"/></Button>
         </span>
-        <span className="mt5">
+        <div className="mt5">
           <CopyToClipboard text={window.vtexjs?.checkout?.orderFormId} onCopy={this.handleCopyOFId}>
             {
               this.state.orderFormIdCopied
@@ -81,7 +84,7 @@ class Actions extends Component {
               : <Button size="small"><FormattedMessage id="cartman.copyCartId"/></Button>
             }
           </CopyToClipboard>
-        </span>
+        </div>
       </div>
     )
   }

--- a/react/components/Actions.js
+++ b/react/components/Actions.js
@@ -71,14 +71,14 @@ class Actions extends Component {
         <span>
           <Button onClick={this.handleResetCartButton} secondary><FormattedMessage id="cartman.emptyCart"/></Button>
         </span>
-        <span>
+        <span className="mt5">
           <CopyToClipboard text={window.vtexjs?.checkout?.orderFormId} onCopy={this.handleCopyOFId}>
-          {
+            {
               this.state.orderFormIdCopied
-              ?  <Alert type="success" onClose={this.handleResetCopyOFIdButton}>
-              <FormattedMessage id="cartman.copiedCart"/>
-            </Alert>
-              : <Button primary>Copiar OF id</Button>
+              ?  <Alert type="success" size="small" onClose={this.handleResetCopyOFIdButton}>
+                  <FormattedMessage id="cartman.copiedCart"/>
+                </Alert>
+              : <Button size="small"><FormattedMessage id="cartman.copyCartId"/></Button>
             }
           </CopyToClipboard>
         </span>

--- a/react/components/Actions.js
+++ b/react/components/Actions.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Button from '@vtex/styleguide/lib/Button'
+import Alert from '@vtex/styleguide/lib/Alert'
 import { generateUrl, getAccountName } from '../utils'
 import { getOrderForm } from '../actions/index'
 import { CopyToClipboard } from 'react-copy-to-clipboard';
@@ -12,7 +13,8 @@ class Actions extends Component {
     super(props)
 
     this.state = {
-      copied: 'false'
+      copied: 'false',
+      orderFormIdCopied: false
     }
   }
 
@@ -20,6 +22,14 @@ class Actions extends Component {
     if (window.vtexjs && window.vtexjs.checkout) {
       window.vtexjs.checkout.removeAllItems()
     }
+  }
+
+  handleCopyOFId = () => {
+    this.setState({...this.state, orderFormIdCopied: true})
+  }
+
+  handleResetCopyOFIdButton = () => {
+    this.setState({...this.state, orderFormIdCopied: false})
   }
 
   handleCopyCartButton = () => {
@@ -60,6 +70,17 @@ class Actions extends Component {
         </span>
         <span>
           <Button onClick={this.handleResetCartButton} secondary><FormattedMessage id="cartman.emptyCart"/></Button>
+        </span>
+        <span>
+          <CopyToClipboard text={window.vtexjs?.checkout?.orderFormId} onCopy={this.handleCopyOFId}>
+          {
+              this.state.orderFormIdCopied
+              ?  <Alert type="success" onClose={this.handleResetCopyOFIdButton}>
+              <FormattedMessage id="cartman.copiedCart"/>
+            </Alert>
+              : <Button primary>Copiar OF id</Button>
+            }
+          </CopyToClipboard>
         </span>
       </div>
     )

--- a/react/locales/en.json
+++ b/react/locales/en.json
@@ -3,6 +3,7 @@
   "cartman.cartmanWarning": "Don't worry! Cartman is NOT visible to your customers :)",
   "cartman.copyCart": "Copy cart link",
   "cartman.copiedCart": "Copied!",
+  "cartman.copyCartId": "Copy cart id",
   "cartman.emptyCart": "Empty cart",
   "cartman.addBySkuId": "Add items by SKU ID",
   "cartman.addRandom": "Add random items",

--- a/react/locales/es.json
+++ b/react/locales/es.json
@@ -3,6 +3,7 @@
   "cartman.cartmanWarning": "¡No te preocupes! Cartman NO es visible para tus clientes :)",
   "cartman.copyCart": "Copiar link del carrito",
   "cartman.copiedCart": "¡Copiado!",
+  "cartman.copyCartId": "Copiar ID del carrito",
   "cartman.emptyCart": "Vaciar carrito",
   "cartman.addBySkuId": "Agregar ítems por ID de SKU",
   "cartman.addRandom": "Agregar ítems al azar",

--- a/react/locales/pt.json
+++ b/react/locales/pt.json
@@ -3,6 +3,7 @@
   "cartman.cartmanWarning": "Não se preocupe! O Cartman NÃO aparece para seus clientes :)",
   "cartman.copyCart": "Copiar link do carrinho",
   "cartman.copiedCart": "Copiado!",
+  "cartman.copyCartId": "Copiar ID do carrinho",
   "cartman.emptyCart": "Carrinho vazio",
   "cartman.addBySkuId": "Adicionar itens pelo ID do SKU",
   "cartman.addRandom": "Adicionar itens aleatórios",


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Add a button to copy current session's cart id (`orderFormId`)

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

It will be useful for debugging 

#### How should this be manually tested?

- Access https://jeff--vtexgame1.myvtex.com/checkout
- Click on cartman button
- Check for the "Copiar id do carrinho" button
- Click to copy cart id
- Check if cart id copy/paste works

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
